### PR TITLE
"typings install" command fails in the starter kit #50 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+    "name": "product-management",
+    "version": "1.0.0",
+    "author": "Deborah Kurata",
+    "description": "Package for the Acme Product Management sample application",
+    "scripts": {
+        "start": "tsc && concurrently \"tsc -w\" \"lite-server\" ",
+        "tsc": "tsc",
+        "tsc:w": "tsc -w",
+        "lint": "tslint ./app/**/*.ts -t verbose",
+        "lite": "lite-server",
+        "typings": "typings",
+        "postinstall": "typings install"
+    },
+    "license": "ISC",
+    "dependencies": {
+        "@angular/common": "2.0.0",
+        "@angular/compiler": "2.0.0",
+        "@angular/core": "2.0.0",
+        "@angular/forms": "2.0.0",
+        "@angular/http": "2.0.0",
+        "@angular/platform-browser": "2.0.0",
+        "@angular/platform-browser-dynamic": "2.0.0",
+        "@angular/router": "3.0.0",
+        "typing": "^0.1.9",
+        "core-js": "^2.4.1",
+        "reflect-metadata": "^0.1.3",
+        "rxjs": "5.0.0-beta.12",
+        "systemjs": "0.19.27",
+        "zone.js": "^0.6.23",
+        
+        "bootstrap": "^3.3.6"
+    },
+    "devDependencies": {
+        "concurrently": "^2.2.0",
+        "lite-server": "^2.2.0",
+        "tslint": "^3.7.4",
+        "typescript": "^2.0.2",
+        "typings": "^1.0.4"
+    },
+    "repository": {}
+}


### PR DESCRIPTION
Updated Typing Node Package Version to latest one.
Regarding this issue https://github.com/DeborahK/Angular2-GettingStarted/issues/50
I have worked on package.json files. Hope this will fix the issue and helps everybody.

Regards,
Narasimha Satti
