### PR TITLE
Automate the development setup with Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,12 @@
+ports:
+  - port: 4200
+    onOpen: open-preview
+tasks:
+  - before: echo N | npm install -g @angular/cli
+    init: >
+      cd APM-Start &&
+      npm install &&
+      cd ..
+    command: >
+      cd APM-Start &&
+      ng serve --host 0.0.0.0 --disable-host-check

--- a/README.md
+++ b/README.md
@@ -20,3 +20,6 @@ For the completed code on stackblitz, check out this link: https://stackblitz.co
 NOTE: If you chose to use Stackblitz, note that it currently does not support reading json files from a folder defined in the angular.json file. Rather, you need to copy the products folder from the api folder to the assets folder. Then modify the productUrl to look in the assets folder: private productUrl = 'assets/products/products.json';
 
 Note also that Stackblitz does not seem to recognize the Font Awesome icons. So you will instead see portions of squares.
+
+Alternatively, you can also work through the course using Gitpod, a one-click online IDE for GitHub, by following this link:
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/DeborahK/Angular-GettingStarted/blob/master/APM-Start/src/app/app.component.html)


### PR DESCRIPTION
Hi @DeborahK, many thanks for making a really good Angular course.

I work on Gitpod.io, a one-click online IDE for GitHub, and I was curious to see if I could run your course material in Gitpod -- it seems to work great!

In this PR, I've configured Gitpod to automatically:
- install the `ng` CLI and other dependencies
- start the app with `ng serve`, and open a web preview
- open `APM-Start/src/app/app.component.html` in the editor, so that you can start live-editing it

Here is what it looks like:

[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/jankeromnes/Angular-GettingStarted/blob/master/APM-Start/src/app/app.component.html)
<img width="1552" alt="Screenshot 2019-07-18 at 14 50 50" src="https://user-images.githubusercontent.com/599268/61459459-0ca24000-a96d-11e9-91e6-8a8a12c0993f.png">
Would you see this being useful for your courses? I'm happy to answer any questions, and to further improve this setup. 🙂